### PR TITLE
add support for snappy compression

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
@@ -17,6 +17,7 @@ import org.apache.hadoop.io.compress.BZip2Codec;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.io.compress.SnappyCodec;
 import org.apache.hadoop.mapred.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,7 @@ public class SequenceFileFormat implements PailFormat {
     public static final String CODEC_ARG_DEFAULT = "default";
     public static final String CODEC_ARG_GZIP = "gzip";
     public static final String CODEC_ARG_BZIP2 = "bzip2";
+    public static final String CODEC_ARG_SNAPPY = "snappy";
 
     private static final Map<String, CompressionType> TYPES = new HashMap<String, CompressionType>() {{
         put(TYPE_ARG_RECORD, CompressionType.RECORD);
@@ -49,6 +51,7 @@ public class SequenceFileFormat implements PailFormat {
         put(CODEC_ARG_DEFAULT, new DefaultCodec());
         put(CODEC_ARG_GZIP, new GzipCodec());
         put(CODEC_ARG_BZIP2, new BZip2Codec());
+        put(CODEC_ARG_SNAPPY, new SnappyCodec());
     }};
 
     private String _typeArg;
@@ -57,7 +60,7 @@ public class SequenceFileFormat implements PailFormat {
     public SequenceFileFormat(Map<String, Object> args) {
         args = new KeywordArgParser()
                 .add(TYPE_ARG, null, true, TYPE_ARG_RECORD, TYPE_ARG_BLOCK)
-                .add(CODEC_ARG, CODEC_ARG_DEFAULT, false, CODEC_ARG_DEFAULT, CODEC_ARG_GZIP, CODEC_ARG_BZIP2)
+                .add(CODEC_ARG, CODEC_ARG_DEFAULT, false, CODEC_ARG_DEFAULT, CODEC_ARG_GZIP, CODEC_ARG_BZIP2, CODEC_ARG_SNAPPY)
                 .parse(args);
         _typeArg = (String) args.get(TYPE_ARG);
         _codecArg = (String) args.get(CODEC_ARG);


### PR DESCRIPTION
this PR adds support for snappy compression, the heavy lifting happens within the hadoop libraries, AWS EMR fully supports snappy compression.
